### PR TITLE
Search for Python3 package instead for newer cmake versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,13 @@ if ( BarElm_LIBRARY )
 endif ( BarElm_LIBRARY )
 
 if ( BUILD_SOLVER_AS_DLL )
-  find_package ( PythonInterp 3 )
+  if ( CMAKE_VERSION VERSION_LESS 3.12 )
+    find_package ( PythonInterp 3 ) # sets ${PYTHON_EXECUTABLE}
+  else ( CMAKE_VERSION VERSION_LESS 3.12 )
+    find_package ( Python3 ) # sets ${Python3_EXECUTABLE}
+    set ( PythonInterp_FOUND ${Python3_FOUND} )
+    set ( PYTHON_EXECUTABLE ${Python3_EXECUTABLE} )
+  endif ( CMAKE_VERSION VERSION_LESS 3.12 )
   if ( PythonInterp_FOUND )
     # Include regression tests for the Inverse python module
     list ( APPEND TEST_DIRS InversePy )

--- a/InversePy/beam_modal_forces/fedem_solver.fao
+++ b/InversePy/beam_modal_forces/fedem_solver.fao
@@ -1,3 +1,3 @@
 #FEDEM options file
 # Additional user-defined options to fedem_solver
--allPrimaryVars-
+-allPrimaryVars- -skylinesolver -nosolveropt -lancz1


### PR DESCRIPTION
Also switching to LANCZ1 eigensolver for one of the regression tests which sometimes fail with SPRLAN (or LANCZ2).