### PR TITLE
Run regression tests with latest solver release

### DIFF
--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2023 SAP SE
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file is part of FEDEM - https://openfedem.org
+
+name: Regression testing
+
+on:
+  pull_request:
+    branches:
+      - main
+
+  workflow_dispatch:
+
+jobs:
+  install-and-test:
+    name: Download solvers and execute tests
+
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Silence some advice/hints and set path
+        run: |
+          git config --global advice.detachedHead false
+          git config --global init.defaultBranch main
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+          echo "LD_LIBRARY_PATH=${{ github.workspace }}/bin" >> $GITHUB_ENV
+
+      - name: Check out source repository
+        uses: actions/checkout@v4
+
+      - name: Download latest FEDEM release
+        uses: robinraju/release-downloader@v1
+        with:
+          repository: openfedem/fedem-solvers
+          fileName: '*_linux64.tar.gz'
+          latest: true
+          extract: true
+
+      - name: Configure the tests
+        run: >
+          cmake -S ./Test -B ./build -DCMAKE_BUILD_TYPE=Release
+          -DUSE_FFTPACK=ON -DFT_LARGE_MODELS=OFF -DFT_TOLERANCE=1.0e-10
+
+      - name: Execute tests
+        run:  cmake --build ./build --target check

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,15 @@
 set ( TEST_DIRS FreeFallTriad SimplePendulum MassSpring BeamModes
                 ConstantCurrent AddedMass InternalFluid
                 ParticleInWaves SoilDegradation CarSuspension CamJoint
-                DampedOscillator Cantilever-extFunc Cantilever-inverse
+                DampedOscillator
                 Tower Frame Sweep SpringDamper RobotArm )
+
+if ( TARGET test_external )
+  list ( APPEND TEST_DIRS Cantilever-extFunc )
+endif ( TARGET test_external )
+if ( TARGET test_inverse )
+  list ( APPEND TEST_DIRS Cantilever-inverse )
+endif ( TARGET test_inverse )
 
 if ( USE_AERODYN_PLUGIN )
   list ( APPEND TEST_DIRS WindTurbine )
@@ -86,9 +93,9 @@ foreach ( TEST ${TEST_DIRS} )
   endif ( EXISTS ${CML_TDA} )
   add_subdirectory ( ${SRC_DIR} ${BIN_DIR} )
   set ( SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${SRC_DIR} )
-  add_custom_command ( TARGET copy_test_input_files
+  add_custom_command ( TARGET copy_test_input_files POST_BUILD
                        COMMAND ${CMAKE_COMMAND} -E copy_directory ${SRC_DIR} ${BIN_DIR} )
-  add_custom_command ( TARGET copy_test_input_files
+  add_custom_command ( TARGET copy_test_input_files POST_BUILD
                        COMMAND ${CMAKE_COMMAND} -E remove -f
                        ${BIN_DIR}/*.md ${BIN_DIR}/CMakeLists.*
                        ${BIN_DIR}/*/*.md ${BIN_DIR}/*/*.png ${BIN_DIR}/*/CMakeLists.* )

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 --->
 
 [![REUSE status](https://api.reuse.software/badge/github.com/openfedem/fedem-solver-tests)](https://api.reuse.software/info/github.com/openfedem/fedem-solver-tests)
+[![Test status](https://github.com/openfedem/fedem-solver-tests/actions/workflows/run_test.yml/badge.svg)](https://github.com/openfedem/fedem-solver-tests/actions/workflows/run_test.yml)
 
 # FEDEM solver regression tests
 

--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2023 SAP SE
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file is part of FEDEM - https://openfedem.org
+
+################################################################################
+# This is the top-level cmake project file for executing the regression tests.
+################################################################################
+
+cmake_minimum_required ( VERSION 2.8...3.10 )
+if ( POLICY CMP0076 )
+  cmake_policy ( SET CMP0076 NEW ) # convert relative target source path names
+endif ( POLICY CMP0076 )
+
+# Project setup
+
+project ( fedemSolverTests NONE )
+
+option ( USE_AERODYN_PLUGIN "Use the AeroDyn wind model library (NREL)" OFF )
+option ( USE_FFTPACK "Build dynamics solver with FFTPack usage" OFF )
+option ( BUILD_TEST_REPORTS "Enable test and profiling reports" OFF )
+mark_as_advanced ( USE_AERODYN_PLUGIN USE_FFTPACK BUILD_TEST_REPORTS )
+
+if ( USE_FFTPACK )
+  set ( FFT_LIBRARY fftpack51 )
+endif ( USE_FFTPACK )
+
+set ( CTEST_OPTIONS --force-new-ctest-process --output-on-failure -O CTest.txt )
+if ( BUILD_TEST_REPORTS )
+  list ( APPEND CTEST_OPTIONS --test-action Test --no-compress-output )
+  # Needed by the profiling execution (see below)
+  set ( MEMORYCHECK_COMMAND_OPTIONS "--tool=callgrind -v" )
+  include ( CTest )
+else ( BUILD_TEST_REPORTS )
+  enable_testing ()
+endif ( BUILD_TEST_REPORTS )
+if ( CMAKE_CONFIGURATION_TYPES )
+  list ( APPEND CTEST_OPTIONS --build-config \"$<CONFIGURATION>\" )
+endif ( CMAKE_CONFIGURATION_TYPES )
+
+# The target check is to be used (instead of test) to ensure that all
+# input files are copied into the build tree before executing the tests.
+add_custom_target ( check COMMAND ${CMAKE_CTEST_COMMAND} ${CTEST_OPTIONS} )
+
+# Setting up profiling with callgrind.
+# Set PROF_RANGE for running a specific number of tests by numbers
+# (must be specified at cmake level, see CTest documentation).
+# cmake ....... -DPROF_RANGE=3,3 (for example)
+
+if ( BUILD_TEST_REPORTS )
+  set ( CTEST_OPTIONS --force-new-ctest-process
+                      -D ExperimentalMemCheck -O CTest.log )
+  if ( PROF_RANGE )
+    list ( APPEND CTEST_OPTIONS -I ${PROF_RANGE} )
+  endif ( PROF_RANGE )
+  add_custom_target ( code_profile
+                      COMMAND ${CMAKE_CTEST_COMMAND} ${CTEST_OPTIONS}
+                      COMMENT "Generating profiling with callgrind"
+                      VERBATIM )
+endif ( BUILD_TEST_REPORTS )
+
+# Now add the actual regression tests
+add_subdirectory ( .. "${CMAKE_CURRENT_BINARY_DIR}/solverTests" )
+add_dependencies ( check copy_test_input_files )

--- a/TimeDomain/Cantilever-inverse/CMakeLists.txt
+++ b/TimeDomain/Cantilever-inverse/CMakeLists.txt
@@ -5,35 +5,39 @@
 # This file is part of FEDEM - https://openfedem.org
 
 set ( TEST_ID Inverse )
-set ( TEST_CMD ${VALGRIND_CMD} ../../test_inverse )
 
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}" )
 
-add_test ( ${TEST_ID} ${TEST_CMD} -fco Setup.fco -timeEnd 10 -timeInc 0.01
+add_test ( NAME ${TEST_ID} COMMAND ${VALGRIND_CMD} test_inverse
+           -fco Setup.fco -timeEnd 10 -timeInc 0.01
            -dis 113 2 17 2 -force 114 2 114 6 -output 1 2 3 4
            -verify Displacements.asc 1.0e-5 )
 
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}-zeroG" )
 
-add_test ( ${TEST_ID}-zeroG ${TEST_CMD} -fco Setup.fco -fsi2file ZeroG.fsi
+add_test ( NAME ${TEST_ID}-zeroG COMMAND ${VALGRIND_CMD} test_inverse
+           -fco Setup.fco -fsi2file ZeroG.fsi
            -dis 113 2 17 2 -dfunc 6 5 -force 114 2 114 6 -output 1 2 3 4
            -verify Master-zeroG.asc 1.0e-5 )
 
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}-Gravity" )
 
-add_test ( ${TEST_ID}-Gravity ${TEST_CMD} -fco Setup.fco -fsi2file Gravity.fsi
+add_test ( NAME ${TEST_ID}-Gravity COMMAND ${VALGRIND_CMD} test_inverse
+           -fco Setup.fco -fsi2file Gravity.fsi
            -dis 113 2 17 2 -dfunc 6 5 -force 114 2 114 6 -output 1 2 3 4
            -verify Master-normalG.asc 1.0e-5 )
 
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}-Dynamic" )
 
-add_test ( ${TEST_ID}-Dynamic ${TEST_CMD} -fco Setup_dyn.fco
+add_test ( NAME ${TEST_ID}-Dynamic COMMAND ${VALGRIND_CMD} test_inverse
+           -fco Setup_dyn.fco
            -dis 113 2 17 2 -force 114 2 114 6 -output 1 2 3 4
            -verify Displacements_dyn.asc 1.0e-5 )
 
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}-DynamicGravity" )
 
-add_test ( ${TEST_ID}-DynamicGravity ${TEST_CMD} -fco Setup_dyn.fco -fsi2file Gravity_dyn.fsi
+add_test ( NAME ${TEST_ID}-DynamicGravity COMMAND ${VALGRIND_CMD} test_inverse
+           -fco Setup_dyn.fco -fsi2file Gravity_dyn.fsi
            -dis 113 2 17 2 -force 114 2 114 6 -output 1 2 3 4
            -verify Displacements_grav_dyn.asc 1.0e-5 )
 
@@ -42,7 +46,8 @@ message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}-Joint" )
 # Redo the Gravity test, but now using a model with a free joint at the tip.
 # Notice the local DOF 4 in the Free Joint is the Z-rotation and not the X-rotation.
 # This is due to the ZYX-parametrization of the joint DOFs.
-add_test ( ${TEST_ID}-Joint ${TEST_CMD} -fco Setup.fco
+add_test ( NAME ${TEST_ID}-Joint COMMAND ${VALGRIND_CMD} test_inverse
+           -fco Setup.fco
            -fsifile ModelWithJoint.fsi -fsi2file Gravity.fsi
            -dis 113 2 17 2 -dfunc 6 5 -force 168 2 168 4 -output 1 2 3 4
            -verify Master-normalG.asc 1.0e-5 )


### PR DESCRIPTION
This will run through (most of) the regression test using the lastest Release from the fedem-solvers repository.
In addition, some CMakeLists.txt fixes to quell warnings with newer cmake versions.